### PR TITLE
Add i18n support to DataTable

### DIFF
--- a/components/common/data-table.tsx
+++ b/components/common/data-table.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { useState, useMemo, useCallback } from "react";
+import { useTranslation } from "@/lib/language-context";
 import {
   Table,
   TableBody,
@@ -124,10 +125,10 @@ export function DataTable<T extends Record<string, any>>({
   actions = [],
   onAdd,
   loading = false,
-  searchPlaceholder = "검색...",
+  searchPlaceholder,
   title,
   subtitle,
-  addButtonText = "추가",
+  addButtonText,
   showSearch = true,
   showFilter = true,
   showExport = false,
@@ -139,7 +140,7 @@ export function DataTable<T extends Record<string, any>>({
   pagination,
   onExport,
   onImport,
-  emptyMessage = "데이터가 없습니다.",
+  emptyMessage,
   stickyHeader = false,
   maxHeight = "calc(100vh - 200px)",
 }: DataTableProps<T>) {
@@ -149,6 +150,11 @@ export function DataTable<T extends Record<string, any>>({
   const [columnFilters, setColumnFilters] = useState<Record<string, any>>({});
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
   const [showFilters, setShowFilters] = useState(false);
+  const { t } = useTranslation("common");
+  const searchPlaceholderText =
+    searchPlaceholder ?? `${t("common.search")}...`;
+  const addButtonTextText = addButtonText ?? t("common.add");
+  const emptyMessageText = emptyMessage ?? t("common.noData");
 
   const getValue = useCallback((record: T, key: string): any => {
     if (!record || !key) return "";
@@ -335,7 +341,7 @@ export function DataTable<T extends Record<string, any>>({
             <div className="relative">
               <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder={searchPlaceholder}
+                placeholder={searchPlaceholderText}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-8 w-64"
@@ -359,7 +365,7 @@ export function DataTable<T extends Record<string, any>>({
             variant="outline"
             size="icon"
             onClick={clearFilters}
-            title="필터 초기화"
+            title={t("dataTable.reset_filters")}
           >
             <RotateCcw className="h-4 w-4" />
           </Button>
@@ -409,7 +415,7 @@ export function DataTable<T extends Record<string, any>>({
           {onAdd && (
             <Button onClick={onAdd}>
               <Plus className="h-4 w-4 mr-2" />
-              {addButtonText}
+              {addButtonTextText}
             </Button>
           )}
         </div>
@@ -439,10 +445,10 @@ export function DataTable<T extends Record<string, any>>({
                         }
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="전체" />
+                          <SelectValue placeholder={t("common.all")} />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="all">전체</SelectItem>
+                          <SelectItem value="all">{t("common.all")}</SelectItem>
                           {column.filterOptions.map((option) => (
                             <SelectItem key={option.value} value={option.value}>
                               {option.label}
@@ -452,7 +458,7 @@ export function DataTable<T extends Record<string, any>>({
                       </Select>
                     ) : (
                       <Input
-                        placeholder={`${column.title} 필터`}
+                        placeholder={`${column.title} ${t("common.filter")}`}
                         value={columnFilters[String(columnKey)] || ""}
                         onChange={(e) =>
                           handleColumnFilter(String(columnKey), e.target.value)
@@ -471,14 +477,15 @@ export function DataTable<T extends Record<string, any>>({
         <div className="bg-blue-50 dark:bg-blue-950 p-3 rounded-lg border border-blue-200 dark:border-blue-800">
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
-              {selectedRows.length}개 항목이 선택됨
+              {t("dataTable.selected_count")
+                .replace("{count}", selectedRows.length.toString())}
             </span>
             <Button
               variant="outline"
               size="sm"
               onClick={() => onSelectedRowsChange?.([])}
             >
-              선택 해제
+              {t("dataTable.deselect")}
             </Button>
           </div>
         </div>
@@ -555,7 +562,7 @@ export function DataTable<T extends Record<string, any>>({
                   </TableHead>
                 ))}
                 {actions.length > 0 && (
-                  <TableHead className="w-[100px]">작업</TableHead>
+                  <TableHead className="w-[100px]">{t("common.action")}</TableHead>
                 )}
               </TableRow>
             </TableHeader>
@@ -572,7 +579,7 @@ export function DataTable<T extends Record<string, any>>({
                   >
                     <div className="flex items-center justify-center">
                       <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
-                      <span className="ml-2">로딩 중...</span>
+                      <span className="ml-2">{t("common.loading")}</span>
                     </div>
                   </TableCell>
                 </TableRow>
@@ -586,7 +593,7 @@ export function DataTable<T extends Record<string, any>>({
                     }
                     className="text-center py-8 text-muted-foreground"
                   >
-                    {emptyMessage}
+                    {emptyMessageText}
                   </TableCell>
                 </TableRow>
               ) : (
@@ -670,14 +677,23 @@ export function DataTable<T extends Record<string, any>>({
       {pagination && (
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground">
-            총 {pagination.total}개 항목 중{" "}
-            {(pagination.page - 1) * pagination.pageSize + 1}-
-            {Math.min(pagination.page * pagination.pageSize, pagination.total)}
-            개 표시
+            {t("dataTable.pagination_summary")
+              .replace("{total}", pagination.total.toString())
+              .replace(
+                "{start}",
+                ((pagination.page - 1) * pagination.pageSize + 1).toString()
+              )
+              .replace(
+                "{end}",
+                Math.min(
+                  pagination.page * pagination.pageSize,
+                  pagination.total
+                ).toString()
+              )}
           </div>
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-2">
-              <span className="text-sm">페이지당 항목:</span>
+              <span className="text-sm">{t("dataTable.items_per_page")}</span>
               <Select
                 value={pagination.pageSize.toString()}
                 onValueChange={(value) =>
@@ -702,7 +718,7 @@ export function DataTable<T extends Record<string, any>>({
                 onClick={() => pagination.onPageChange(1)}
                 disabled={pagination.page === 1}
               >
-                처음
+                {t("dataTable.first")}
               </Button>
               <Button
                 variant="outline"
@@ -710,7 +726,7 @@ export function DataTable<T extends Record<string, any>>({
                 onClick={() => pagination.onPageChange(pagination.page - 1)}
                 disabled={pagination.page === 1}
               >
-                이전
+                {t("common.previous")}
               </Button>
               <span className="px-3 py-1 text-sm">
                 {pagination.page} /{" "}
@@ -725,7 +741,7 @@ export function DataTable<T extends Record<string, any>>({
                   Math.ceil(pagination.total / pagination.pageSize)
                 }
               >
-                다음
+                {t("common.next")}
               </Button>
               <Button
                 variant="outline"
@@ -740,7 +756,7 @@ export function DataTable<T extends Record<string, any>>({
                   Math.ceil(pagination.total / pagination.pageSize)
                 }
               >
-                마지막
+                {t("dataTable.last")}
               </Button>
             </div>
           </div>
@@ -751,10 +767,22 @@ export function DataTable<T extends Record<string, any>>({
       <div className="flex items-center justify-between text-sm text-muted-foreground">
         <div>
           {searchTerm || Object.keys(columnFilters).length > 0
-            ? `필터링된 ${sortedData.length}개 항목 (전체 ${data.length}개)`
-            : `총 ${data.length}개 항목`}
+            ? t("dataTable.filtered_summary")
+                .replace("{filtered}", sortedData.length.toString())
+                .replace("{total}", data.length.toString())
+            : t("dataTable.total_summary").replace(
+                "{count}",
+                data.length.toString()
+              )}
         </div>
-        {selectedRows.length > 0 && <div>{selectedRows.length}개 선택됨</div>}
+        {selectedRows.length > 0 && (
+          <div>
+            {t("dataTable.selected_count").replace(
+              "{count}",
+              selectedRows.length.toString()
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -146,5 +146,16 @@
       "boolean": "Y or N",
       "default": "Text input"
     }
+  },
+  "dataTable": {
+    "reset_filters": "Reset Filters",
+    "pagination_summary": "Showing {start}-{end} of {total} items",
+    "items_per_page": "Items per page:",
+    "first": "First",
+    "last": "Last",
+    "selected_count": "{count} selected",
+    "filtered_summary": "{filtered} items filtered (total {total})",
+    "total_summary": "Total {count} items",
+    "deselect": "Deselect"
   }
 }

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -146,5 +146,16 @@
       "boolean": "YまたはN",
       "default": "テキスト入力"
     }
+  },
+  "dataTable": {
+    "reset_filters": "フィルターをリセット",
+    "pagination_summary": "全{total}件中{start}-{end}件表示",
+    "items_per_page": "ページあたり件数:",
+    "first": "最初",
+    "last": "最後",
+    "selected_count": "{count}件選択済み",
+    "filtered_summary": "{total}件中{filtered}件を表示",
+    "total_summary": "合計 {count} 件",
+    "deselect": "選択解除"
   }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -568,6 +568,17 @@
       "health": "설비 건강지수"
     }
   },
+  "dataTable": {
+    "reset_filters": "필터 초기화",
+    "pagination_summary": "총 {total}개 항목 중 {start}-{end}개 표시",
+    "items_per_page": "페이지당 항목:",
+    "first": "처음",
+    "last": "마지막",
+    "selected_count": "{count}개 선택됨",
+    "filtered_summary": "필터링된 {filtered}개 항목 (전체 {total}개)",
+    "total_summary": "총 {count}개 항목",
+    "deselect": "선택 해제"
+  },
   "import": {
     "empty_file": "파일이 비어있습니다.",
     "missing_header": "필수 헤더가 없습니다: {header}"

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -146,5 +146,16 @@
       "boolean": "Y或N",
       "default": "文本输入"
     }
+  },
+  "dataTable": {
+    "reset_filters": "重置过滤器",
+    "pagination_summary": "共{total}项，显示{start}-{end}项",
+    "items_per_page": "每页条目数:",
+    "first": "首页",
+    "last": "末页",
+    "selected_count": "已选择{count}项",
+    "filtered_summary": "已筛选{filtered}项 (共{total}项)",
+    "total_summary": "共 {count} 项",
+    "deselect": "取消选择"
   }
 }


### PR DESCRIPTION
## Summary
- internationalize DataTable component
- add DataTable translations for ko, en, ja and zh

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ed626be48328a7584e2410e3e690